### PR TITLE
feat: generate "good" and "bad" trace log files.

### DIFF
--- a/runtime/compiler/control/DebugAgent.cpp
+++ b/runtime/compiler/control/DebugAgent.cpp
@@ -244,7 +244,7 @@ debugAgentRevertToInterpreter(J9VMThread* vmThread, J9JITExceptionTable *jitMeth
     }
 
 extern J9_CFUNC BOOLEAN
-debugAgentRecompile(J9VMThread* vmThread, J9JITExceptionTable *jitMethod, IDATA lastOptIndex, IDATA lastOptSubIndex, BOOLEAN enableTracing)
+debugAgentRecompile(J9VMThread* vmThread, J9JITExceptionTable *jitMethod, IDATA lastOptIndex, IDATA lastOptSubIndex, BOOLEAN enableTracing, BOOLEAN goodLog)
     {
     J9JITConfig *jitConfig = vmThread->javaVM->jitConfig;
     if (NULL == jitConfig)
@@ -297,7 +297,23 @@ debugAgentRecompile(J9VMThread* vmThread, J9JITExceptionTable *jitMethod, IDATA 
         }
 
     plan->setInsertInstrumentation(bodyInfo->getIsProfilingBody());
-    // plan->setLogCompilation(jitdumpFile);
+
+    char *fileName = "goodJitCompilationLog_opt_index_";
+    if (!goodLog)
+    {
+        fileName = "badJitCompilationLog_opt_index_";
+    }
+    // Ref: https://github.com/eclipse-openj9/openj9-omr/blob/openj9/compiler/ras/Tree.cpp#L1168
+    int numDigits = ( lastOptIndex == 0 ? 1 : ((int) log10( (double)lastOptIndex ) + 1) );
+    int maxSize = strlen(fileName) + numDigits + 5;
+    char fileNameWithLastOptIndex[maxSize];
+    snprintf(fileNameWithLastOptIndex, maxSize, "%s%d.log", fileName, (int)lastOptIndex);
+    TR::FILE *jitCompilationLog = enableTracing ? trfopen(fileNameWithLastOptIndex, "ab", false) : NULL;
+    if (enableTracing)
+    {
+        plan->setLogCompilation(jitCompilationLog);
+        TR::Options::getCmdLineOptions()->setOption(TR_TraceAll);
+    }
 
     TR::Options::getCmdLineOptions()->setLastOptIndex(lastOptIndex);
     TR::Options::getCmdLineOptions()->setLastOptSubIndex(lastOptSubIndex);
@@ -310,6 +326,11 @@ debugAgentRecompile(J9VMThread* vmThread, J9JITExceptionTable *jitMethod, IDATA 
     auto rc = compilationOK;
     auto queued = false;
     compInfo->compileMethod(vmThread, details, pc, TR_no, &rc, &queued, plan);
+    if (enableTracing)
+    {
+        trfflush(jitCompilationLog);
+        trfclose(jitCompilationLog);
+    }
 
     vmThread->javaVM->internalVMFunctions->internalReleaseVMAccess(vmThread);
 

--- a/runtime/compiler/control/DebugAgent.hpp
+++ b/runtime/compiler/control/DebugAgent.hpp
@@ -37,7 +37,7 @@ extern J9_CFUNC BOOLEAN
 debugAgentRevertToInterpreter(J9VMThread* vmThread, J9JITExceptionTable *jitMethod);
 
 extern J9_CFUNC BOOLEAN
-debugAgentRecompile(J9VMThread* vmThread, J9JITExceptionTable *jitMethod, IDATA lastOptIndex, IDATA lastOptSubIndex, BOOLEAN enableTracing);
+debugAgentRecompile(J9VMThread* vmThread, J9JITExceptionTable *jitMethod, IDATA lastOptIndex, IDATA lastOptSubIndex, BOOLEAN enableTracing, BOOLEAN goodLog);
 
 extern J9_CFUNC BOOLEAN
 debugAgentEnd(J9VMThread* vmThread);

--- a/runtime/jcl/common/jithelpers.c
+++ b/runtime/jcl/common/jithelpers.c
@@ -515,7 +515,7 @@ Java_com_ibm_jit_JITHelpers_debugAgentRun(JNIEnv *env, jclass ignored, jobject m
 			IDATA lastOptSubIndex = 1024;
 
 			for (IDATA lastOptIndex = 100; lastOptIndex >= 0; --lastOptIndex) {
-				jitConfig->debugAgentRecompile(vmThread, (J9JITExceptionTable*)jitMethod, lastOptIndex, lastOptSubIndex, 0);
+				jitConfig->debugAgentRecompile(vmThread, (J9JITExceptionTable*)jitMethod, lastOptIndex, lastOptSubIndex, 0, 0);
 
 				fprintf(stderr, "Rerunning test\n");
 				(*env)->CallObjectMethod(env, ma, jdk_internal_reflect_MethodAccessor_invoke, obj, args);
@@ -525,7 +525,7 @@ Java_com_ibm_jit_JITHelpers_debugAgentRun(JNIEnv *env, jclass ignored, jobject m
 				} else {
 					fprintf(stderr, "LastOptIndex = %ld is the potential culprit\n", lastOptIndex + 1);
 
-					jitConfig->debugAgentRecompile(vmThread, (J9JITExceptionTable*)jitMethod, lastOptIndex, lastOptSubIndex, 1);
+					jitConfig->debugAgentRecompile(vmThread, (J9JITExceptionTable*)jitMethod, lastOptIndex, lastOptSubIndex, 1, 1);
 
 					fprintf(stderr, "Rerunning test expecting it to pass\n");
 					(*env)->CallObjectMethod(env, ma, jdk_internal_reflect_MethodAccessor_invoke, obj, args);
@@ -537,7 +537,7 @@ Java_com_ibm_jit_JITHelpers_debugAgentRun(JNIEnv *env, jclass ignored, jobject m
 						fprintf(stderr, "Test passed\n");
 					}
 
-					jitConfig->debugAgentRecompile(vmThread, (J9JITExceptionTable*)jitMethod, lastOptIndex + 1, lastOptSubIndex, 1);
+					jitConfig->debugAgentRecompile(vmThread, (J9JITExceptionTable*)jitMethod, lastOptIndex + 1, lastOptSubIndex, 1, 0);
 
 					fprintf(stderr, "Rerunning test expecting it to fail\n");
 					(*env)->CallObjectMethod(env, ma, jdk_internal_reflect_MethodAccessor_invoke, obj, args);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4035,7 +4035,7 @@ typedef struct J9JITConfig {
 	BOOLEAN (*debugAgentStart)(struct J9VMThread *vmThread);
 	BOOLEAN (*debugAgentGetAllJitMethods)(struct J9VMThread *vmThread, jobject jitMethods);
 	BOOLEAN (*debugAgentRevertToInterpreter)(struct J9VMThread *vmThread, J9JITExceptionTable *jitMethod);
-	BOOLEAN (*debugAgentRecompile)(struct J9VMThread *vmThread, J9JITExceptionTable *jitMethod, IDATA lastOptIndex, IDATA lastOptSubIndex, BOOLEAN enableTracing);
+	BOOLEAN (*debugAgentRecompile)(struct J9VMThread *vmThread, J9JITExceptionTable *jitMethod, IDATA lastOptIndex, IDATA lastOptSubIndex, BOOLEAN enableTracing, BOOLEAN goodLog);
 	BOOLEAN (*debugAgentEnd)(struct J9VMThread *vmThread);
 #if defined(J9VM_OPT_JITSERVER)
 	int32_t (*startJITServer)(struct J9JITConfig *jitConfig);


### PR DESCRIPTION
Made changes to the Debug Agent to produce a JITDump log for the optimization that causes failure and JITDump for the optimization that succeeds. This information helps compare the buggy JIT-compiled code with the code that works.

**Log Name and Examples**
* Log files where the test last passed will be named
goodJitCompilationLog_opt_index_<num>.log

ex: [goodJitCompilationLog_opt_index_64.log](https://github.com/r30shah/openj9-jit-debug-agent/files/7263287/goodJitCompilationLog_opt_index_64.log)

* Log files where the test fail will be named
badJitCompilationLog_opt_index_<num>.log

ex: [badJitCompilationLog_opt_index_65.log](https://github.com/r30shah/openj9-jit-debug-agent/files/7263290/badJitCompilationLog_opt_index_65.log)

Closes: #2
Signed-off-by: Qasim Khawaja <khawaja@ualberta.ca>
