### PR TITLE
Updated JITHelpers class to avoid false positives

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java
+++ b/jcl/src/java.base/share/classes/com/ibm/jit/JITHelpers.java
@@ -50,6 +50,7 @@ public final class JITHelpers {
 
 	private static final JITHelpers helpers;
 	private static final Unsafe unsafe;
+	private static java.util.concurrent.ConcurrentHashMap<String, Class<? extends Throwable>> exceptionMap;
 
 	private JITHelpers() {
 	}
@@ -67,6 +68,50 @@ public final class JITHelpers {
 	 */
 	private static JITHelpers jitHelpers() {
 		return helpers;
+	}
+
+	/**
+	 * Set the expected exception for the current thread.
+	 * Initializes the exceptionMap if necessary.
+	 * 
+	 * @param expectedException The class of the expected exception.
+	 */
+
+	public static void setExpectedException(Class<? extends Throwable> expectedException) {
+		Thread currentThread = Thread.currentThread();
+		String vmThreadName = currentThread.getName();
+		initExceptionMap();
+		
+		if (expectedException == null) {
+			exceptionMap.remove(vmThreadName);
+		}
+		else {
+			exceptionMap.put(vmThreadName, expectedException);
+		}
+	}
+
+	/**
+	 * Get the expected exception for the current thread.
+	 * 
+	 * @return The class of the expected exception.
+	 */
+
+	public static Class<? extends Throwable> getExpectedException() {
+		Thread currentThread = Thread.currentThread();
+		if(exceptionMap == null) {
+			return null;
+		}
+		return exceptionMap.get(currentThread.getName());
+	}
+
+	/**
+	 * Synchronized method to instantiate an exceptionMap if it does not exist
+	 */
+
+	public synchronized static void initExceptionMap() {
+		if (exceptionMap == null) {
+			exceptionMap = new java.util.concurrent.ConcurrentHashMap<String, Class<? extends Throwable>>();
+		}
 	}
 
 	public native int transformedEncodeUTF16Big(long src, long dest, int num);
@@ -1180,18 +1225,44 @@ public final class JITHelpers {
 
 	private native static final void debugAgentRun(MethodAccessor ma, Object obj, Object[] args);
 
+	/**
+	 * Invokes the method on the object with the given MethodAccessor and arguments.
+	 * If the method throws an exception, it is caught and if the exception is unexpected,
+	 * the debug agent triggered.
+	 * 
+	 * @param ma the method to run the debug agent on.
+	 * @param obj the underlying object.
+	 * @param args the arguments for the method
+	 * @return the return value of the method
+	 */
 	public static Object invoke(MethodAccessor ma, Object obj, Object[] args) throws InvocationTargetException {
 		try {
 			return ma.invoke(obj, args);
 		} catch (InvocationTargetException e) {
 			if (e.getCause() != null && e.getCause().getClass().getName().equals("java.lang.NullPointerException")) {
-				// TODO: Need synchronization to prevent many threads entering here
-				System.err.println("Caught java.lang.NullPointerException inside JITHelpers");
-
-				debugAgentRun(ma, obj, args);
+				Class < ? extends Throwable > expected = com.ibm.jit.JITHelpers.getExpectedException();
+				boolean runDebugAgent = true;
+				if (expected != null) {
+					Throwable targetException = e.getTargetException();
+					if (!expected.isAssignableFrom(targetException.getClass())) {
+						String message = "From JITHelpers.invoke - Unexpected exception, expected<" +
+							expected.getName() + "> but was<" +
+							targetException.getClass().getName() + ">";
+						System.out.println(message);
+					} else {
+						runDebugAgent = false;
+					}
+				}
+				if (runDebugAgent) {
+					synchronized (JITHelpers.class) {
+						System.err.println("Caught java.lang.NullPointerException inside JITHelpers, thread "+Thread.currentThread().getName());
+						e.getCause().printStackTrace();
+						debugAgentRun(ma, obj, args);
 				
-				System.err.println("Aborting JVM");
-				System.exit(1);
+						System.err.println("Aborting JVM");
+						System.exit(1);
+					}
+				}
 			}
 
 			throw e;


### PR DESCRIPTION
Created methods to allow an expected exception to be set from the test framework.
Verifies if the thrown exception is unexpected before running
the debugging agent. More details are found in #5.

The JITHelpers class now supports:
- Setting an expected exception
- Getting an expected exception
- Weed out false positives from triggering debugging agent.

Closes: #5
Signed-off-by: Qasim Khawaja <khawaja@ualberta.ca>


Here are some further tests that I ran to verify my implementation:
[Multi Threaded (expected exception thrown with no bug enabled)](https://github.com/r30shah/openj9-jit-debug-agent/files/7524599/multi-threaded-expected-exception-no-bug.log)
[Multi Threaded (unexpected exception thrown with no bug enabled](https://github.com/r30shah/openj9-jit-debug-agent/files/7524600/multi-threaded-unexpected-exception-no-bug.log)
[Single Threaded (bug enabled)](https://github.com/r30shah/openj9-jit-debug-agent/files/7524602/single-threaded-bug-enabled.log)

### Callout
@r30shah These are two more tests that I ran with the bug enabled with the multithreaded tests. No synchronization causes the debug agent to end with a trace log and the same exception trace from #7. ( I have your latest fix)
I was able to resolve this by turning the block that runs the agent to be synchronized. (Line 1246)
[not-synced-multithreaded-bug-enabled.log](https://github.com/r30shah/openj9-jit-debug-agent/files/7524601/not-synced-multithreaded-bug-enabled.log)
[synced-multithreaded-bug-enabled.log](https://github.com/r30shah/openj9-jit-debug-agent/files/7524603/synced-multithreaded-bug-enabled.log)